### PR TITLE
Prevent proto2cpp.py script to parse itself

### DIFF
--- a/proto2cpp.py
+++ b/proto2cpp.py
@@ -226,7 +226,7 @@ class proto2cpp:
 
 converter = proto2cpp()
 # Doxygen will give us the file names
-for filename in sys.argv:
+for filename in sys.argv[1:]:
     converter.handleFile(filename)
 
 # end of file


### PR DESCRIPTION
The script iterates over all file names on the command line, but by doing
that it also parses the python script itself (argument 0). Fixed that.

Signed-off-by: Ivo Sieben <ivo.sieben@philips.com>